### PR TITLE
Fix gui for entering frequency above 2.1 GHz.

### DIFF
--- a/src/gui/setting_slots.cpp
+++ b/src/gui/setting_slots.cpp
@@ -32,7 +32,7 @@
 
 void MainWindow::on_spinBox_rf_freq_editingFinished()//RF-Freq changed:
 {
-    glob_settings.glob_args.decoder_args.rf_freq = ui->spinBox_rf_freq->value() * 1000;   //Save Value to glob_args
+    glob_settings.glob_args.decoder_args.rf_freq = (double)ui->spinBox_rf_freq->value() * 1000.0;   //Save Value to glob_args
     ui->lcdNumber_rf_freq->display(glob_settings.glob_args.decoder_args.rf_freq);  //Display rf_freq
 
     if(glob_settings.glob_args.gui_args.save_settings)glob_settings.store_settings();  //If save_settings = true, save to file.


### PR DESCRIPTION
One line computed frequency in Hz as int32_t before assignment,
and therefore went negative above 2^31 Hz (2.147... GHz).

Cast it to double.

Allows operation in band 7, e.g. 2.625 GHz.