### PR TITLE
Fixes #8 - C linkage error

### DIFF
--- a/lib/include/falcon/meas/probe_modem.h
+++ b/lib/include/falcon/meas/probe_modem.h
@@ -20,11 +20,12 @@
  */
 #pragma once
 
+#include "cmnalib/at_sierra_wireless_em7565.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-#include "cmnalib/at_sierra_wireless_em7565.h"
 
 //#define DEFAULT_URL "mptcp1.pi21.de:5002"
 #define DEFAULT_URL "www.kn.e-technik.tu-dortmund.de"


### PR DESCRIPTION
As reported by @NerdyProjects in https://github.com/falkenber9/falcon/issues/8, changes in GLib result in the following build error:

```
src/falcon-1.3.0/lib/include/falcon/meas/probe_modem.h:24:1: note: ‘extern "C"’ linkage started here
   24 | extern "C" {
      | ^~~~~~~~~~
In file included from /usr/include/glib-2.0/glib/gatomic.h:31,
                 from /usr/include/glib-2.0/glib/gthread.h:32,
                 from /usr/include/glib-2.0/glib/gasyncqueue.h:32,
                 from /usr/include/glib-2.0/glib.h:32,
                 from /usr/include/glib-2.0/gmodule.h:28,
                 from /usr/include/cmnalib/at_sierra_wireless_em7565.h:12,
```

As discussed [here](https://gitlab.gnome.org/GNOME/glib/-/merge_requests/1935#note_1030395) and implemented [here](https://src.fedoraproject.org/rpms/icecat/blob/902a94597e0d48bbe3e1ebc3184787f7b6fe9242/f/icecat-78.7.1-fix_error_template_with_C_linkage.patch) the issue can be fixed by moving the `include` statement out of the `extern` block.

Tested the build on Ubuntu 22.04 which works fine without further changes.